### PR TITLE
Fixes blocking check highlighting

### DIFF
--- a/app/src/main/java/polymorphs/a301/f17/cs414/thexgame/AppBackend/Board.java
+++ b/app/src/main/java/polymorphs/a301/f17/cs414/thexgame/AppBackend/Board.java
@@ -347,8 +347,7 @@ class Board {
                 if (to.getTileStatus() != Status.INSIDE_BLACK) return false;
             }
             if (!king.isValidMove(toRow,toCol)) return false;
-            if (moveResultsInCheck(king,fromRow,fromCol,toRow,toCol)) return false;
-            return true;
+            return moveResultsInCheck(king,fromRow,fromCol,toRow,toCol);
         }
         return false;
     }


### PR DESCRIPTION
Fixes error where all tiles of a path to block check are highlighted instead of the tile that blocks check only.